### PR TITLE
カーリルのISBNを取得できない問題を修正

### DIFF
--- a/js/openbd.js
+++ b/js/openbd.js
@@ -34,7 +34,7 @@ const SITES = [
   },
   {
     url: 'https://calil.jp/book/',
-    isbnSelector: document.querySelectorAll('.bookarea')[2],
+    isbnSelector: document.querySelectorAll('.bookarea'),
     targetElement: document.querySelectorAll('.detailheader')[1],
     insert: 'before'
   },


### PR DESCRIPTION
ページのCSSクラス仕様を分かっていなくてちょっと自信がないのですが、取得した要素配列のインデックスがおかしかったので修正しました。